### PR TITLE
Update grpc to 1.18.0

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -13,10 +13,10 @@ repositories {
 
 dependencies {
     compile("com.google.protobuf:protobuf-java:3.6.1")
-    compile("io.grpc:grpc-stub:1.17.1")
-    compile("io.grpc:grpc-protobuf:1.17.1")
-    runtime("io.grpc:grpc-netty-shaded:1.17.1")
-    compile("io.grpc:grpc-services:1.17.1")
+    compile("io.grpc:grpc-stub:1.18.0")
+    compile("io.grpc:grpc-protobuf:1.18.0")
+    runtime("io.grpc:grpc-netty-shaded:1.18.0")
+    compile("io.grpc:grpc-services:1.18.0")
     compile("org.eclipse.jgit:org.eclipse.jgit:5.2.1.201812262042-r")
     // Support common types like, color, date, latlng, ...
     compile 'com.google.api.grpc:proto-google-common-protos:1.14.0'


### PR DESCRIPTION
Resulted in Jib staging the wrong dependency for a project dependent on this one.